### PR TITLE
Sync package-lock to 1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woo-custom-my-account-page",
-  "version": "1.6.2",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woo-custom-my-account-page",
-      "version": "1.6.2",
+      "version": "1.6.4",
       "license": "GPL-2.0+",
       "devDependencies": {
         "grunt": "^1.6.0",


### PR DESCRIPTION
Lockfile left behind by the 1.6.4 release. package.json was bumped and committed; the lockfile only updated locally when npm install ran during the build. No customer impact (excluded from the zip), but the tagged tree should be self-consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lbi1bWYKU6PEMGcm2fx7VF