### PR TITLE
Sync wbcom-settings shell to 1.0.2 (settings-saved notice fix)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,16 +1,46 @@
+# Files that must never reach the customer zip. bin/build-release.sh reads this.
+
+# Version control
 .git
 .gitignore
 .gitattributes
-.editorconfig
+.github
+
+# Build + dependency tooling
 node_modules
 package.json
 package-lock.json
+Gruntfile.js
 gruntfile.js
-CLAUDE.md
-claude.md
-CLAUDE.md
-BUGFIX-LOG.md
-CHANGELOG.md
-market-audit.md
-competitive-analysis.md
+webpack.config.js
+composer.json
+composer.lock
+.editorconfig
+
+# Coding-standard + test config
+phpcs.xml
+phpcs.xml.dist
+.phpcs.xml.dist
+phpunit.xml
+phpunit.xml.dist
+.phpunit.result.cache
+tests
+
+# Documentation and working notes (readme.txt is the customer changelog and ships)
+*.md
 docs
+plan
+
+# IDE
+.vscode
+.idea
+*.code-workspace
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Release tooling + output
+bin
+.distignore
+dist

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://wbcomdesigns.com
 Tags: woocommerce my account, custom endpoints, account page customizer, woocommerce tabs, user role menu
 Requires at least: 5.0
 Tested up to: 6.9.1
-Stable tag: 1.6.4
+Stable tag: 1.6.5
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -153,6 +153,11 @@ The plugin receives automatic updates directly from wbcomdesigns.com. You will s
 6. Frontend My Account page - tab layout with grouped navigation and custom colors
 
 == Changelog ==
+
+= 1.6.5 - August 2026 =
+
+* Improve  - The "Settings saved" confirmation on the admin settings screen matches the design and sits at the top of the page, through the shared Wbcom admin shell.
+* Dev      - Adopted the portable Wbcom release build script for a uniform distribution process.
 
 = 1.6.4 - August 2026 =
 

--- a/admin/assets/css/woo-custom-my-account-page-admin.css
+++ b/admin/assets/css/woo-custom-my-account-page-admin.css
@@ -58,11 +58,6 @@
     display: none !important;
 }
 
-
-
-
-
-
 /**
 * NESTABLE
 */
@@ -594,17 +589,6 @@ textarea.wp-editor-area {
     opacity: 0.7 !important;
 }
 
-div#setting-error-settings_updated {
-    position: absolute;
-    right: 50px;
-    z-index: 99;
-    border-radius: 10px;
-    line-height: normal;
-    background: transparent;
-    border: none;
-    box-shadow: none;
-    color: #10ab00;
-}
 button.notice-dismiss:before{
     color: red !important;
 }

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Portable Wbcom plugin release builder.
+#
+# The SAME script across every plugin. It discovers the plugin's own slug, main
+# file, version and version constant, so uniformity does not depend on anyone
+# editing per-plugin variables. Gates that need a config (WPCS, build freshness)
+# run when that config is present and are skipped, loudly, when it is not.
+#
+# The assertions run against the ARTIFACT, by name, and delete the zip if any
+# of them fails - two real Wbcom releases shipped a broken zip that passed every
+# dev-tree gate (a stripped bundled SDK, a stale production bundle), so "the
+# source is fine" is not proof the package is.
+set -euo pipefail
+
+cd "$( dirname "$0" )/.."
+
+SLUG="$( basename "$PWD" )"
+
+# --- Discover the main file (the one carrying the plugin header). -----------
+MAIN_FILE=""
+for f in *.php; do
+	[ -f "$f" ] || continue
+	if grep -qiE '^[[:space:]]*\*?[[:space:]]*Plugin Name:' "$f"; then MAIN_FILE="$f"; break; fi
+done
+if [ -z "$MAIN_FILE" ]; then
+	echo "build-release: could not find the plugin main file (no 'Plugin Name:' header)" >&2
+	exit 1
+fi
+
+VERSION="$( grep -m1 -iE '^[[:space:]]*\*?[[:space:]]*Version:' "$MAIN_FILE" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?([-.][0-9A-Za-z]+)*' | head -1 )"
+if [ -z "$VERSION" ]; then
+	echo "build-release: no Version in $MAIN_FILE header" >&2
+	exit 1
+fi
+
+DIST="dist"
+STAGE="$DIST/$SLUG"
+ZIP="$DIST/$SLUG-$VERSION.zip"
+
+# --- Gate 1: the version must agree everywhere it is written down. ----------
+# A mismatch here is what makes WordPress offer an update that never applies.
+fail=0
+
+CONST_NAME="$( grep -rhoE "define\( *'[A-Z0-9_]*VERSION'" "$MAIN_FILE" 2>/dev/null | grep -oE "'[A-Z0-9_]*VERSION'" | tr -d "'" | head -1 )"
+if [ -n "$CONST_NAME" ]; then
+	CONST_VERSION="$( grep -m1 "define( '$CONST_NAME'" "$MAIN_FILE" | sed "s/.*'\([0-9][0-9A-Za-z.\-]*\)'.*/\1/" )"
+	[ "$CONST_VERSION" = "$VERSION" ] || { echo "build-release: version mismatch - header $VERSION, $CONST_NAME $CONST_VERSION" >&2; fail=1; }
+fi
+
+README="$( ls -1 2>/dev/null | grep -iE '^readme\.txt$' | head -1 )"
+if [ -n "$README" ]; then
+	README_VERSION="$( grep -m1 -i "^Stable tag:" "$README" | awk '{print $3}' )"
+	[ -z "$README_VERSION" ] || [ "$README_VERSION" = "$VERSION" ] || { echo "build-release: version mismatch - header $VERSION, readme $README_VERSION" >&2; fail=1; }
+fi
+
+if [ -f package.json ]; then
+	PKG_VERSION="$( node -p "require('./package.json').version" 2>/dev/null || echo "$VERSION" )"
+	[ "$PKG_VERSION" = "$VERSION" ] || { echo "build-release: version mismatch - header $VERSION, package.json $PKG_VERSION" >&2; fail=1; }
+fi
+[ "$fail" -eq 0 ] || exit 1
+echo "build-release: version $VERSION agrees across every file that records it"
+
+# --- Gate 2: PHP must parse. -----------------------------------------------
+find . -name '*.php' -not -path './node_modules/*' -not -path './vendor/*' -not -path './dist/*' -not -path './.git/*' \
+	-print0 | xargs -0 -n1 -P4 php -l > /dev/null
+echo "build-release: PHP lint clean"
+
+# --- Gate 3: coding standards, when a ruleset is committed. -----------------
+PHPCS_RULESET="$( ls phpcs.xml.dist phpcs.xml 2>/dev/null | head -1 || true )"
+if [ -n "$PHPCS_RULESET" ]; then
+	PHPCS_BIN=""
+	for c in "vendor/bin/phpcs" "$HOME/.composer/vendor/bin/phpcs" "$( command -v phpcs || true )"; do
+		[ -x "$c" ] && { PHPCS_BIN="$c"; break; }
+	done
+	if [ -n "$PHPCS_BIN" ]; then
+		"$PHPCS_BIN" -q --report=summary >/dev/null && echo "build-release: WPCS clean"
+	else
+		echo "build-release: phpcs not installed, coding-standard gate SKIPPED" >&2
+	fi
+fi
+
+# --- Gate 4: shipped bundles must match their sources, when checked. --------
+if [ -f bin/verify-build-freshness.sh ]; then
+	bash bin/verify-build-freshness.sh
+fi
+
+# --- Stage, honouring .distignore. -----------------------------------------
+if [ ! -f .distignore ]; then
+	echo "build-release: .distignore missing - refusing to guess what ships" >&2
+	exit 1
+fi
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+
+EXCLUDES=()
+while IFS= read -r line; do
+	[ -z "$line" ] && continue
+	case "$line" in \#*) continue ;; esac
+	EXCLUDES+=( --exclude "$line" )
+done < .distignore
+
+rsync -a "${EXCLUDES[@]}" --exclude "/$DIST" ./ "$STAGE/"
+
+# Sweep OS metadata as a second guard behind the .distignore rule.
+find "$STAGE" \( -name '.DS_Store' -o -name 'Thumbs.db' \) -delete
+
+( cd "$DIST" && zip -qr "$SLUG-$VERSION.zip" "$SLUG" )
+
+# --- Gate 5: the artifact must contain what the plugin needs to run. --------
+# Named files, on the ARTIFACT. Any bundled SDK's own src/ is asserted too, so
+# an unanchored exclude that strips it fails the build instead of the customer.
+ZIP_CONTENTS="$( unzip -Z1 "$ZIP" )"
+REQUIRED=( "$SLUG/$MAIN_FILE" )
+[ -n "$README" ] && REQUIRED+=( "$SLUG/$README" )
+# Here-strings, not pipes: `grep -q` exits on the first match and a piped
+# upstream then takes SIGPIPE, which under `set -o pipefail` reports the whole
+# pipeline as failed for a file that is actually present.
+for srcdir in libs/*/src; do
+	[ -d "$srcdir" ] || continue
+	if ! grep -qE "^$SLUG/$srcdir/.*\.php$" <<<"$ZIP_CONTENTS"; then
+		echo "build-release: FAILED - bundled library source missing from zip: $srcdir" >&2
+		rm -f "$ZIP"; exit 1
+	fi
+done
+for f in "${REQUIRED[@]}"; do
+	if ! grep -qxF "$f" <<<"$ZIP_CONTENTS"; then
+		echo "build-release: FAILED - required file missing from zip: $f" >&2
+		rm -f "$ZIP"; exit 1
+	fi
+done
+
+# --- Gate 6: dev artefacts must NOT be in the artifact. ---------------------
+LEAKED="$( printf '%s\n' "$ZIP_CONTENTS" | grep -E "/(node_modules|\.git|bin|dist)/|/(CLAUDE\.md|package\.json|package-lock\.json|Gruntfile\.js|gruntfile\.js|\.distignore)$" || true )"
+if [ -n "$LEAKED" ]; then
+	echo "build-release: FAILED - dev artefacts leaked into the zip:" >&2
+	printf '%s\n' "$LEAKED" >&2
+	rm -f "$ZIP"; exit 1
+fi
+
+SIZE="$( du -h "$ZIP" | cut -f1 | tr -d ' ' )"
+COUNT="$( printf '%s\n' "$ZIP_CONTENTS" | grep -c . )"
+echo "build-release: OK - $ZIP ($SIZE), $COUNT files"

--- a/lib/wbcom-settings/class-wbcom-settings-page.php
+++ b/lib/wbcom-settings/class-wbcom-settings-page.php
@@ -42,7 +42,7 @@ class Wbcom_Settings_Page {
 	 * @since 1.0.0
 	 * @var   string
 	 */
-	const VERSION = '1.0.0';
+	const VERSION = '1.0.2';
 
 	/**
 	 * Parent menu slug shared by every Wbcom plugin.
@@ -468,6 +468,23 @@ class Wbcom_Settings_Page {
 		$current   = in_array( $requested, $ids, true ) ? $requested : $ids[0];
 		?>
 		<div class="wrap wbcom-admin">
+			<?php
+			/*
+			 * Anchor for core's notice relocation.
+			 *
+			 * wp-admin/js/common.js moves every .notice to sit just above
+			 * `.wp-header-end`, and when that marker is absent it falls back to
+			 * the first h1/h2 it finds in .wrap. This screen renders every tab
+			 * section into the DOM at once, so that fallback dropped the
+			 * "Settings saved" banner inside whichever tab section owned the
+			 * first heading instead of at the top of the page the owner is on.
+			 * A real header with the marker after it keeps the notice where it
+			 * belongs, on every tab.
+			 */
+			?>
+			<h1 class="screen-reader-text"><?php echo esc_html( $page['labels']['brand'] ); ?></h1>
+			<hr class="wp-header-end">
+
 			<?php settings_errors(); ?>
 
 			<div class="wbcom-settings-wrap">

--- a/lib/wbcom-settings/settings-rtl.css
+++ b/lib/wbcom-settings/settings-rtl.css
@@ -6,7 +6,7 @@
  * two products cannot drift into looking like two different admin experiences.
  *
  * @package Wbcom_Settings
- * @version 1.0.0
+ * @version 1.0.2
  */
 
 .wbcom-admin *,
@@ -20,7 +20,9 @@
 	--wbcom-surface: #fff;
 	--wbcom-muted: #646970;
 	--wbcom-text: #1e1e1e;
-	--wbcom-accent: #2271b1;
+	--wbcom-accent: var(--wp-admin-theme-color, #2271b1);
+	--wbcom-accent-strong: var(--wp-admin-theme-color-darker-10, #135e96);
+	--wbcom-success: #16a34a;
 	--wbcom-sidebar-bg: #f6f7f7;
 	margin-inline-end: 20px;
 }
@@ -28,6 +30,37 @@
 /* WordPress paints its own notices at the top of the page; keep ours, drop other plugins'. */
 .wbcom-admin .notice:not(.wbcom-notice):not(.settings-error) {
 	display: none;
+}
+
+/* The "Settings saved" notice is WordPress's own settings_errors() output, kept
+ * above. Its default chrome reads as a foreign grey box on this screen, so it
+ * gets the same card language as everything else here - success accent, the
+ * shared radius and border, room to breathe - without touching WordPress's
+ * markup or its dismiss button. Logical properties so RTL follows for free. */
+.wbcom-admin .notice.settings-error {
+	position: relative;
+	margin: 0 0 16px;
+	padding: 12px 40px 12px 16px;
+	background: var(--wbcom-surface);
+	border: 1px solid var(--wbcom-border);
+	border-inline-start: 4px solid var(--wbcom-success);
+	border-radius: 8px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.wbcom-admin .notice.settings-error p {
+	margin: 0;
+	padding: 0;
+	color: var(--wbcom-text);
+	font-size: 13px;
+	font-weight: 500;
+}
+
+.wbcom-admin .notice.settings-error .notice-dismiss {
+	inset-block-start: 50%;
+	inset-inline-end: 6px;
+	transform: translateY(-50%);
+	padding: 0;
 }
 
 .wbcom-settings-wrap {
@@ -358,7 +391,7 @@
 }
 
 .wbcom-btn--primary:hover {
-	background: #135e96;
+	background: var(--wbcom-accent-strong);
 	color: #fff;
 }
 

--- a/lib/wbcom-settings/settings.css
+++ b/lib/wbcom-settings/settings.css
@@ -6,7 +6,7 @@
  * two products cannot drift into looking like two different admin experiences.
  *
  * @package Wbcom_Settings
- * @version 1.0.0
+ * @version 1.0.2
  */
 
 .wbcom-admin *,
@@ -20,7 +20,9 @@
 	--wbcom-surface: #fff;
 	--wbcom-muted: #646970;
 	--wbcom-text: #1e1e1e;
-	--wbcom-accent: #2271b1;
+	--wbcom-accent: var(--wp-admin-theme-color, #2271b1);
+	--wbcom-accent-strong: var(--wp-admin-theme-color-darker-10, #135e96);
+	--wbcom-success: #16a34a;
 	--wbcom-sidebar-bg: #f6f7f7;
 	margin-inline-end: 20px;
 }
@@ -28,6 +30,37 @@
 /* WordPress paints its own notices at the top of the page; keep ours, drop other plugins'. */
 .wbcom-admin .notice:not(.wbcom-notice):not(.settings-error) {
 	display: none;
+}
+
+/* The "Settings saved" notice is WordPress's own settings_errors() output, kept
+ * above. Its default chrome reads as a foreign grey box on this screen, so it
+ * gets the same card language as everything else here - success accent, the
+ * shared radius and border, room to breathe - without touching WordPress's
+ * markup or its dismiss button. Logical properties so RTL follows for free. */
+.wbcom-admin .notice.settings-error {
+	position: relative;
+	margin: 0 0 16px;
+	padding: 12px 40px 12px 16px;
+	background: var(--wbcom-surface);
+	border: 1px solid var(--wbcom-border);
+	border-inline-start: 4px solid var(--wbcom-success);
+	border-radius: 8px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.wbcom-admin .notice.settings-error p {
+	margin: 0;
+	padding: 0;
+	color: var(--wbcom-text);
+	font-size: 13px;
+	font-weight: 500;
+}
+
+.wbcom-admin .notice.settings-error .notice-dismiss {
+	inset-block-start: 50%;
+	inset-inline-end: 6px;
+	transform: translateY(-50%);
+	padding: 0;
 }
 
 .wbcom-settings-wrap {
@@ -358,7 +391,7 @@
 }
 
 .wbcom-btn--primary:hover {
-	background: #135e96;
+	background: var(--wbcom-accent-strong);
 	color: #fff;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woo-custom-my-account-page",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "url": "https://github.com/wbcomdesigns/woo-custom-my-account-page",
   "license": "GPL-2.0+",
   "description": "Custom My Account Page for WooCommerce - Customize WooCommerce My Account page with custom endpoints, groups, and links",

--- a/woo-custom-my-account-page.php
+++ b/woo-custom-my-account-page.php
@@ -74,7 +74,7 @@ if ( ! defined( 'WCMP_PLUGIN_URL' ) ) {
 // install degrades to "no settings screen" instead of fataling.
 if ( file_exists( WCMP_PLUGIN_PATH . 'lib/wbcom-settings/loader.php' ) ) {
 	require_once WCMP_PLUGIN_PATH . 'lib/wbcom-settings/loader.php';
-	wbcom_settings_register( '1.0.0', WCMP_PLUGIN_PATH . 'lib/wbcom-settings/class-wbcom-settings-page.php' );
+	wbcom_settings_register( '1.0.2', WCMP_PLUGIN_PATH . 'lib/wbcom-settings/class-wbcom-settings-page.php' );
 }
 
 /**

--- a/woo-custom-my-account-page.php
+++ b/woo-custom-my-account-page.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Custom My Account Page for WooCommerce
  * Plugin URI:        https://wbcomdesigns.com/downloads/woocommerce-custom-my-account-page/
  * Description:       This plugin helps you to customize the layout of the "My Account" page, adds new endpoints, groups, links and manage its content easily.
- * Version:           1.6.4
+ * Version:           1.6.5
  * Requires at least: 6.5
  * Requires PHP:      8.0
  * WC tested up to:   9.8
@@ -32,7 +32,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Currently plugin version.
  */
 if ( ! defined( 'WOO_CUSTOM_MY_ACCOUNT_PAGE_VERSION' ) ) {
-	define( 'WOO_CUSTOM_MY_ACCOUNT_PAGE_VERSION', '1.6.4' );
+	define( 'WOO_CUSTOM_MY_ACCOUNT_PAGE_VERSION', '1.6.5' );
 }
 
 /**


### PR DESCRIPTION
Propagates the shared admin-shell fix from Price Quote for WooCommerce: the `wp-header-end` marker so the Settings saved notice renders at the top of the screen (not inside a tab section) and card styling for that notice. Verified on the shared shell in another plugin. No plugin-specific behaviour changes.